### PR TITLE
Loosen bounds for `time` and `base`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,9 @@ matrix:
     - env: CABALVER=2.2 GHCVER=8.4.1
       compiler: ": #GHC 8.4.1"
       addons: {apt: {packages: [cabal-install-2.2,ghc-8.4.1], sources: [hvr-ghc]}}
+    - env: CABALVER=2.2 GHCVER=8.8.3
+      compiler: ": #GHC 8.8.3"
+      addons: {apt: {packages: [cabal-install-2.2,ghc-8.8.3], sources: [hvr-ghc]}}
 
 before_install:
  - unset CC

--- a/ekg-wai.cabal
+++ b/ekg-wai.cabal
@@ -28,6 +28,7 @@ tested-with:         GHC == 7.10.3
                    , GHC == 8.0.2
                    , GHC == 8.2.2
                    , GHC == 8.4.1
+                   , GHC == 8.8.3
 
 library
   exposed-modules:
@@ -40,7 +41,7 @@ library
 
   build-depends:
     aeson,
-    base >= 4.8 && < 4.12,
+    base >= 4.8 && < 4.14,
     bytestring < 1.0,
     ekg-core >= 0.1 && < 0.2,
     ekg-json >= 0.1 && < 0.2,
@@ -48,7 +49,7 @@ library
     http-types,
     network,
     text < 1.3,
-    time < 1.9,
+    time < 1.10,
     transformers < 0.6,
     unordered-containers < 0.3,
     wai,


### PR DESCRIPTION
Builds with GHC 8.8.3