### PR TITLE
Don't rethrow ThreadKilled exceptions (ported from ekg:ce0aece)

### DIFF
--- a/System/Remote/Monitoring/Wai.hs
+++ b/System/Remote/Monitoring/Wai.hs
@@ -45,6 +45,7 @@ module System.Remote.Monitoring.Wai
     ) where
 
 import Control.Concurrent (ThreadId, myThreadId, throwTo)
+import Control.Exception (AsyncException(ThreadKilled), fromException)
 import Data.Int (Int64)
 import Data.Time.Clock.POSIX (getPOSIXTime)
 import Prelude hiding (read)
@@ -230,8 +231,10 @@ forkServerWith store host port = do
     me <- myThreadId
     tid <- withSocketsDo $ forkFinally (startServer store host port) $ \ r ->
         case r of
-            Left e  -> throwTo me e
             Right _ -> return ()
+            Left e  -> case fromException e of
+                Just ThreadKilled -> return ()
+                _                 -> throwTo me e
     return $! Server tid store
   where
     getTimeMs :: IO Int64

--- a/ekg-wai.cabal
+++ b/ekg-wai.cabal
@@ -1,5 +1,5 @@
 name:                ekg-wai
-version:             0.1.1.0
+version:             0.1.2.0
 synopsis:            Remote monitoring of processes
 description:
   This library lets you remotely monitor a running process over HTTP.
@@ -29,6 +29,7 @@ tested-with:         GHC == 7.10.3
                    , GHC == 8.2.2
                    , GHC == 8.4.1
                    , GHC == 8.8.3
+                   , GHC == 9.6.5
 
 library
   exposed-modules:


### PR DESCRIPTION
With `ekg-wai`, I faced the same issue as described in https://github.com/haskell-github-trust/ekg/issues/62

Therefore, this PR ports the exact commit from `ekg` that fixes it (cf. https://github.com/haskell-github-trust/ekg/pull/63)
